### PR TITLE
fix: add explicit permissions to slash-command-dispatch workflow

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -2,6 +2,12 @@ name: Slash Command Dispatch
 on:
   issue_comment:
     types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   slashCommandDispatch:
     name: Dispatch


### PR DESCRIPTION
- Add contents:read, issues:write, pull-requests:write permissions
- Fixes reaction token warning when setting reactions on comments
- Ensures proper permissions for slash command dispatch functionality