### PR TITLE
fix: add actions:write permission for workflow dispatch

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   slashCommandDispatch:


### PR DESCRIPTION
# fix: add actions:write permission for workflow dispatch

## Summary

This PR fixes the "Resource not accessible by integration" error that occurs when using slash commands in GitHub issues/PRs. The error was preventing the peter-evans/slash-command-dispatch action from successfully triggering workflow_dispatch events for the `/devin`, `/ai-fix`, and `/ai-help` commands.

**Root Cause**: The slash-command-dispatch workflow lacked the `actions:write` permission required to dispatch other workflows.

**Solution**: Added `actions: write` to the permissions block in `.github/workflows/slash-command-dispatch.yml`.

## Review & Testing Checklist for Human

- [ ] **Test slash commands end-to-end** - Comment `/ai-help`, `/ai-fix`, or `/devin` on a GitHub issue/PR to verify the "Resource not accessible by integration" error is resolved
- [ ] **Security review** - Verify that `actions:write` permission is appropriately scoped and follows principle of least privilege for workflow dispatch functionality  
- [ ] **Permission verification** - Confirm this is the minimal permission needed to fix the integration error (no additional permissions required)

**Recommended Test Plan**: 
1. Comment `/ai-help test` on any GitHub issue in this repository
2. Verify the slash command dispatch workflow runs without the integration error
3. Confirm the ai-help-command workflow is successfully triggered

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    Issue["GitHub Issue/PR<br/>Comment: /ai-help"]
    Dispatch[".github/workflows/<br/>slash-command-dispatch.yml"]:::major-edit
    SCD["peter-evans/<br/>slash-command-dispatch@v3"]:::context
    AiHelp[".github/workflows/<br/>ai-help-command.yml"]:::context
    AiFix[".github/workflows/<br/>ai-fix-command.yml"]:::context
    DevinCmd[".github/workflows/<br/>devin-command.yml"]:::context
    Action["./action.yml<br/>(Devin API call)"]:::context

    Issue -->|"issue_comment event"| Dispatch
    Dispatch -->|"uses"| SCD
    SCD -->|"workflow_dispatch"| AiHelp
    SCD -->|"workflow_dispatch"| AiFix  
    SCD -->|"workflow_dispatch"| DevinCmd
    AiHelp -->|"uses ./"| Action
    AiFix -->|"uses ./"| Action
    DevinCmd -->|"uses ./"| Action

    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- This change addresses a follow-up issue discovered after merging the initial slash command implementation (PR #4)
- The error occurred because GitHub's workflow dispatch requires explicit `actions:write` permission, which was not included in the initial permissions block
- All other workflow permissions (`contents:read`, `issues:write`, `pull-requests:write`) remain unchanged
- **Session requested by**: @aaronsteers
- **Link to Devin session**: https://app.devin.ai/sessions/3585a4601dff44298e7e72be73f061dc