### PR TITLE
feat: inject PR response instruction when comment-id is provided

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ runs:
           comment_author=$(echo $COMMENT_JSON | jq -r .user.login)
 
           prompt_parts+=("Comment from @${comment_author}: ${comment_body}")
+          
+          # Add PR response instruction when comment-id is provided
+          prompt_parts+=("IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR.")
         fi
 
         # Add issue context if issue-number is provided

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
           prompt_parts+=("Comment from @${comment_author}: ${comment_body}")
           
           # Add PR response instruction when comment-id is provided
-          pr_response_instruction="IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR."
+          pr_response_instruction="IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR. Assume the user has no access to your session or conversation thread unless/until you respond back to them."
           prompt_parts+=("$pr_response_instruction")
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
           prompt_parts+=("Comment from @${comment_author}: ${comment_body}")
           
           # Add PR response instruction when comment-id is provided
-          pr_response_instruction="IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR. Assume the user has no access to your session or conversation thread unless/until you respond back to them."
+          pr_response_instruction="IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the respective issue PR. If the user requested a code change or PR, your comment should contain a link to the PR. Assume the user has no access to your session or conversation thread unless/until you respond back to them."
           prompt_parts+=("$pr_response_instruction")
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,8 @@ runs:
           prompt_parts+=("Comment from @${comment_author}: ${comment_body}")
           
           # Add PR response instruction when comment-id is provided
-          prompt_parts+=("IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR.")
+          pr_response_instruction="IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR."
+          prompt_parts+=("$pr_response_instruction")
         fi
 
         # Add issue context if issue-number is provided


### PR DESCRIPTION
# feat: inject PR response instruction when comment-id is provided

## Summary
This PR injects a specific instruction into the Devin prompt when the `comment-id` parameter is provided to the action. The instruction tells Devin to post exactly one comment back to the PR and include a PR link if the user requested a PR.

**Key Changes:**
- Modified the prompt building logic in `action.yml` to add the PR response instruction when `comment-id` is present
- The instruction is added after the comment context but before other prompt components
- Only triggers when the action is invoked with a `comment-id` (typically from slash commands or PR/issue comments)

## Review & Testing Checklist for Human
- [ ] **Verify instruction text accuracy** - Confirm the exact wording matches the requirement: "IMPORTANT: The user will expect a response posted back to the PR. You should post exactly one comment back to the PR, unless otherwise requested. If the user requested a PR, your comment should contain a link to the PR."
- [ ] **Test YAML syntax** - Validate the action.yml file parses correctly and doesn't break existing functionality
- [ ] **Test prompt construction** - Trigger the action with a `comment-id` parameter and verify the instruction appears in the Devin prompt preview
- [ ] **End-to-end verification** - If possible, test with a real PR comment to ensure Devin actually receives and follows the instruction

**Recommended Test Plan:**
1. Use the action in a test repository with `comment-id` set
2. Check the "📝 Devin Prompt Preview" output in the GitHub Action logs
3. Verify the instruction appears in the prompt when `comment-id` is provided
4. Verify the instruction does NOT appear when `comment-id` is not provided

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["action.yml<br/>(GitHub Action)"]:::major-edit --> B["Build Devin prompt step"]:::major-edit
    B --> C["comment-id check"]:::major-edit
    C -->|if comment-id provided| D["Fetch comment context"]:::context
    D --> E["Add comment to prompt_parts"]:::context
    E --> F["Add PR response instruction"]:::major-edit
    C -->|if no comment-id| G["Skip comment processing"]:::context
    F --> H["Continue with other prompt parts"]:::context
    G --> H
    H --> I["Send prompt to Devin API"]:::context

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#ffffff
```

### Notes
- This change was requested by @aaronsteers (AJ Steers)
- The instruction is only injected when `comment-id` is provided, which indicates the action was triggered from a PR or issue comment
- The placement after comment context ensures the instruction is prominent in the prompt
- Unable to test end-to-end without live Devin API access - human testing recommended
- Link to Devin session: https://app.devin.ai/sessions/d395971ca99b40108e9f89e375eecf2e