### PR TITLE
fix: Pass github-token to comment actions for GitHub App support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,7 @@ runs:
       uses: peter-evans/create-or-update-comment@v4
       id: comment-start
       with:
+        token: ${{ inputs.github-token }}
         comment-id: ${{ inputs.comment-id }}
         issue-number: ${{ inputs.issue-number }}
         body: |
@@ -256,6 +257,7 @@ runs:
       if: steps.comment-start.outputs.comment-id && success()
       uses: peter-evans/create-or-update-comment@v4
       with:
+        token: ${{ inputs.github-token }}
         comment-id: ${{ steps.comment-start.outputs.comment-id }}
         reactions: hooray
         body: |
@@ -267,6 +269,7 @@ runs:
       if: failure() && steps.comment-start.outputs.comment-id
       uses: peter-evans/create-or-update-comment@v4
       with:
+        token: ${{ inputs.github-token }}
         comment-id: ${{ steps.comment-start.outputs.comment-id }}
         reactions: confused
         body: |


### PR DESCRIPTION
# fix: Pass github-token to comment actions for GitHub App support

## Summary
The `peter-evans/create-or-update-comment` action defaults to using `GITHUB_TOKEN` when no token is provided. This works for workflows where `GITHUB_TOKEN` has sufficient permissions, but fails with 403 "Resource not accessible by integration" errors when a GitHub App token is needed (e.g., slash command workflows in airbytehq/airbyte).

This fix passes the `github-token` input to all three comment steps so that callers can provide a custom token (like a GitHub App token) when needed. When `github-token` is not provided, the peter-evans action should fall back to its default behavior.

**Root cause:** The `github-token` input was being used for the `gh` CLI in the build-prompt step, but was not being passed to the comment actions.

## Review & Testing Checklist for Human
- [ ] Verify that when `github-token` is not provided, the peter-evans action falls back gracefully to `GITHUB_TOKEN` (backward compatibility)
- [ ] Test by re-running `/ai-prove-fix` on [PR #70202](https://github.com/airbytehq/airbyte/pull/70202) after merging this fix

### Notes
- Related failure: https://github.com/airbytehq/airbyte/actions/runs/20143443158
- Devin session: https://app.devin.ai/sessions/a9367a5c411d438e83a7a08c54ecc7f5
- Requested by: AJ Steers (@aaronsteers)