### PR TITLE
feat: Add v3 API support with advanced_mode and bypass_approval

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,12 +42,15 @@ inputs:
   org-id:
     description: "Organization ID (required for v3 API). Can be found in Devin organization settings"
     required: false
-  auto-approve:
-    description: "If 'true', auto-approve the session without manual approval (v3 API only)"
+  bypass-approval:
+    description: "If 'true', bypass approval for batch session creation (v3 API batch mode only). Requires UseDevinExpert permission"
     required: false
     default: "false"
-  advanced:
-    description: "Advanced execution mode (v3 API only). Set to 'bulk' for bulk session orchestration"
+  advanced-mode:
+    description: "Advanced execution mode (v3 API only). Available modes: 'batch' (start multiple sessions), 'analyze' (analyze sessions), 'create' (create playbook), 'improve' (improve playbook), 'manage' (manage knowledge)"
+    required: false
+  child-playbook-id:
+    description: "Playbook ID for child sessions (required for 'batch' and 'improve' advanced modes)"
     required: false
 
 runs:
@@ -207,8 +210,9 @@ runs:
         # Determine API version and endpoint
         api_version="${{ inputs.api-version }}"
         org_id="${{ inputs.org-id }}"
-        auto_approve="${{ inputs.auto-approve }}"
-        advanced="${{ inputs.advanced }}"
+        bypass_approval="${{ inputs.bypass-approval }}"
+        advanced_mode="${{ inputs.advanced-mode }}"
+        child_playbook_id="${{ inputs.child-playbook-id }}"
 
         if [[ "$api_version" == "v3" ]]; then
           # Validate org-id is provided for v3 API
@@ -219,17 +223,25 @@ runs:
           api_endpoint="https://api.devin.ai/v3beta1/organizations/${org_id}/sessions"
           echo "Using v3 API endpoint: $api_endpoint"
 
+          # Validate child_playbook_id is provided for batch/improve modes
+          if [[ "$advanced_mode" == "batch" || "$advanced_mode" == "improve" ]] && [[ -z "$child_playbook_id" ]]; then
+            echo "Error: child-playbook-id is required when using advanced-mode '$advanced_mode'"
+            exit 1
+          fi
+
           # Build v3 API request payload with additional parameters
           jq -n \
             --arg prompt "$decoded_prompt" \
             --argjson tags "$tags_array" \
-            --argjson auto_approve "$(if [[ "$auto_approve" == "true" ]]; then echo true; else echo false; fi)" \
-            --arg advanced "$advanced" \
+            --argjson bypass_approval "$(if [[ "$bypass_approval" == "true" ]]; then echo true; else echo false; fi)" \
+            --arg advanced_mode "$advanced_mode" \
+            --arg child_playbook_id "$child_playbook_id" \
             '{
               "prompt": $prompt,
               "tags": $tags
-            } + (if $auto_approve then {"auto_approve": true} else {} end)
-              + (if $advanced != "" then {"advanced": $advanced} else {} end)' > devin_request.json
+            } + (if $advanced_mode != "" then {"advanced_mode": $advanced_mode} else {} end)
+              + (if $advanced_mode == "batch" and $bypass_approval then {"bypass_approval": true} else {} end)
+              + (if $child_playbook_id != "" then {"child_playbook_id": $child_playbook_id} else {} end)' > devin_request.json
         else
           # v1 API (default)
           api_endpoint="https://api.devin.ai/v1/sessions"


### PR DESCRIPTION
## Blocker

> [!Warning]
> This feature requires an Enterprise Devin account. Cannot test using our current permissions.

## Summary

Adds support for Devin's v3 API (`/v3beta1/organizations/{org_id}/sessions`) while maintaining backward compatibility with the existing v1 API.

**New inputs:**
- `api-version`: Choose between `v1` (default) or `v3`
- `org-id`: Required for v3 API
- `bypass-approval`: Bypass approval for batch session creation (v3 batch mode only, requires UseDevinExpert permission)
- `advanced-mode`: Advanced execution mode (v3 only). Available modes: `batch`, `analyze`, `create`, `improve`, `manage`
- `child-playbook-id`: Playbook ID for child sessions (required for `batch` and `improve` modes)

The v1 API remains the default, so existing workflows are unaffected.

## Updates since last revision

- Corrected v3 API parameter names based on actual documentation:
  - `auto-approve` → `bypass-approval` (only applies to batch mode)
  - `advanced` → `advanced-mode` with documented values
- Added `child-playbook-id` input (required for batch/improve modes)
- Added validation to fail early if `child-playbook-id` is missing when using batch/improve modes

## Review & Testing Checklist for Human

- [ ] **Verify jq conditional logic**: The v3 payload uses jq object merging with string comparisons (`$advanced_mode == "batch"`). Test with `dry-run: true` to confirm valid JSON is produced for: (1) no advanced_mode, (2) batch mode with bypass_approval, (3) batch mode without bypass_approval
- [ ] **Test v3 API end-to-end**: Create a test workflow using `api-version: v3` with valid `org-id`, `devin-token` (cog_* format), and `advanced-mode: batch` to confirm the endpoint and payload work correctly
- [ ] **Confirm v1 backward compatibility**: Run an existing workflow without the new inputs to ensure v1 behavior is unchanged

**Recommended test plan:**
1. Run the action with `dry-run: true` and `api-version: v3` to inspect the generated payload
2. Test batch mode: `advanced-mode: batch`, `child-playbook-id: <valid-id>`, `bypass-approval: true`
3. Verify an existing v1 workflow still works

### Notes

This PR is part of a larger effort to add bulk API monitoring capabilities. A companion PR in `airbytehq/oncall` (https://github.com/airbytehq/oncall/pull/10549) adds a workflow that will use these new v3 features.

Requested by @aaronsteers.

Link to Devin run: https://app.devin.ai/sessions/eee60b8875a14656bfa6418c21568c26