### PR TITLE
feat: Add outputs block to expose session-id, session-url, and other outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,23 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  session-id:
+    description: "The Devin session ID"
+    value: ${{ steps.devin-session.outputs.session-id }}
+  session-url:
+    description: "The URL to view the Devin session"
+    value: ${{ steps.devin-session.outputs.session-url }}
+  prompt:
+    description: "The base64-encoded prompt sent to Devin"
+    value: ${{ steps.build-prompt.outputs.prompt }}
+  prompt_readable:
+    description: "The human-readable prompt sent to Devin"
+    value: ${{ steps.build-prompt.outputs.prompt_readable }}
+  run-url:
+    description: "The GitHub Actions run URL"
+    value: ${{ steps.vars.outputs.run-url }}
+
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Summary

Adds an `outputs` block to the composite action to expose internal step outputs to calling workflows. Without this block, workflows using this action cannot access `session-id`, `session-url`, or other outputs because composite actions don't automatically propagate internal step outputs.

This was discovered when the `ai-release-manager-kickoff` workflow in `airbytehq/oncall` tried to use `${{ steps.devin-session.outputs.session-id }}` but received empty values, even though the action itself was successfully creating sessions.

**Outputs added:**
- `session-id` - The Devin session ID
- `session-url` - The URL to view the Devin session  
- `prompt` - The base64-encoded prompt sent to Devin
- `prompt_readable` - The human-readable prompt
- `run-url` - The GitHub Actions run URL

## Review & Testing Checklist for Human

- [ ] Verify the step IDs referenced (`devin-session`, `build-prompt`, `vars`) match the actual step IDs in the action
- [ ] After merging and releasing a new tag, test by using the action in a workflow and confirming `${{ steps.<step-id>.outputs.session-id }}` returns a non-empty value

**Recommended test plan:** After releasing a new tag (e.g., v0.1.8), update `airbytehq/oncall` to use the new version and re-run the `ai-release-manager-kickoff` workflow to verify the session ID is now captured correctly in the issue comment.

### Notes

Requested by @aaronsteers.

Link to Devin run: https://app.devin.ai/sessions/ecb615a5745c4a62b37e8771f74f5b00