### PR TITLE
docs: add CONTRIBUTING.md with Releasing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing!
 
-## Releasing
+## 🚀 Releasing
 
-This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. For full details on how releases work, see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).
+This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. To release, simply click "`Edit`" on the latest release draft from the [releases page](https://github.com/aaronsteers/devin-action/releases), and then click "`Publish release`". This publish operation will trigger all necessary downstream publish operations.
+
+ℹ️ For more detailed instructions, please see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).


### PR DESCRIPTION
# docs: add CONTRIBUTING.md with Releasing section

## Summary

Adds a `CONTRIBUTING.md` with a `## 🚀 Releasing` section that includes:
- Inline release instructions with a direct link to this repo's [releases page](https://github.com/aaronsteers/devin-action/releases)
- A link to the shared [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md) in `semantic-pr-release-drafter` for more detail

This is part of a cross-repo effort to ensure all repos using `semantic-pr-release-drafter` have consistent releasing documentation without duplicating instructions.

The shared guide is being added in [aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41).

### Updates since last revision

- Updated heading to `## 🚀 Releasing`
- Added inline release instructions with repo-specific [releases page](https://github.com/aaronsteers/devin-action/releases) link
- Added ℹ️ callout linking to the detailed Releasing Guide

## Review & Testing Checklist for Human

- [ ] **Verify the [releases page link](https://github.com/aaronsteers/devin-action/releases) points to the correct repo.** It should be `aaronsteers/devin-action`, not another repo from the batch.
- [ ] **Verify the Releasing Guide link won't 404.** The target doc (`docs/releasing.md`) is added in [aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41). That PR should be merged first (or simultaneously).

### Notes

- Docs-only change, no code or workflow modifications.
- Part of a batch of PRs across 9 consumer repos plus the upstream releasing guide.

---
Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/d59fa353515f488ab1818b8888d0c3bf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/devin-action/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
