### PR TITLE
feat: support org-id with reuse-session via v3 message endpoint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -407,7 +407,11 @@ runs:
           session_url="https://app.devin.ai/sessions/${session_id}"
           echo "Final session ID: $session_id"
           echo "Final session URL: $session_url"
-          echo "API endpoint: POST /v1/sessions/${session_id}/message"
+          if [[ -n "${{ inputs.org-id }}" ]]; then
+            echo "API endpoint: POST /v3/organizations/{org_id}/sessions/devin-${session_id}/messages (org-scoped)"
+          else
+            echo "API endpoint: POST /v1/sessions/${session_id}/message"
+          fi
           echo "::endgroup::"
           
           # Output resolved values
@@ -460,18 +464,24 @@ runs:
           exit 0
         fi
 
-        # Build curl headers
-        curl_headers=(-H "Authorization: Bearer ${DEVIN_TOKEN}" -H "Content-Type: application/json")
+        # Select API endpoint based on whether org-id is provided
         if [[ -n "${DEVIN_ORG_ID}" ]]; then
-          echo "Including org-id header for org-scoped authentication"
-          curl_headers+=(-H "X-Devin-Org-Id: ${DEVIN_ORG_ID}")
+          # Use v3 message endpoint for org-scoped sessions (e.g. sessions created via v3 API)
+          devin_id="devin-${session_id}"
+          api_url="https://api.devin.ai/v3/organizations/${DEVIN_ORG_ID}/sessions/${devin_id}/messages"
+          echo "Using v3 message endpoint (org-scoped): POST /v3/organizations/{org_id}/sessions/${devin_id}/messages"
+        else
+          # Use v1 message endpoint for personal sessions
+          api_url="https://api.devin.ai/v1/sessions/${session_id}/message"
+          echo "Using v1 message endpoint: POST /v1/sessions/${session_id}/message"
         fi
 
         # Make API call to send message to existing session
         response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
-          "${curl_headers[@]}" \
+          -H "Authorization: Bearer ${DEVIN_TOKEN}" \
+          -H "Content-Type: application/json" \
           -d @devin_request.json \
-          "https://api.devin.ai/v1/sessions/${session_id}/message")
+          "$api_url")
 
         # Extract HTTP status code
         http_status=$(echo "$response" | grep "HTTP_STATUS:" | cut -d':' -f2)

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     description: "Additional tags to apply to the Devin session (supports CSV or line-delimited format). Automatic tags are always added: gh-actions-trigger and playbook-{macro-name} if playbook-macro is provided. Cannot be used with reuse-session."
     required: false
   reuse-session:
-    description: "Existing Devin session ID or URL to inject a message into (optional). When provided, sends a message to an existing session instead of creating a new one. Accepts either a session ID or a full URL (e.g., https://app.devin.ai/sessions/abc123). Mutually exclusive with 'tags' input."
+    description: "Existing Devin session ID or URL to inject a message into (optional). When provided, sends a message to an existing session instead of creating a new one. Accepts either a session ID or a full URL (e.g., https://app.devin.ai/sessions/abc123). Mutually exclusive with 'tags' input. When targeting a session created via the v3 API, also provide 'org-id' for org-scoped authentication."
     required: false
   dry-run:
     description: "If 'true', the action will simulate the process without making an actual API call to Devin"
@@ -63,7 +63,7 @@ inputs:
     description: "Session URLs or IDs to provide as context (optional, supports CSV or line-delimited format). Required when advanced-mode is 'analyze'. When provided without advanced-mode, defaults to 'analyze' mode automatically."
     required: false
   org-id:
-    description: "Devin organization ID (required when using v3 API features such as advanced-mode or session-links). For org-scoped service users this may be auto-resolved, but providing it explicitly is recommended."
+    description: "Devin organization ID (required when using v3 API features such as advanced-mode or session-links). Also used with reuse-session to authenticate against sessions created via the v3 API. For org-scoped service users this may be auto-resolved, but providing it explicitly is recommended."
     required: false
   max-acu-limit:
     description: "Maximum ACU limit for the session (optional, v3 API only). Caps the compute budget for the session."
@@ -421,6 +421,7 @@ runs:
       shell: bash
       env:
         DEVIN_TOKEN: ${{ inputs.devin-token }}
+        DEVIN_ORG_ID: ${{ inputs.org-id }}
       run: |
         set -euo pipefail
 
@@ -431,6 +432,7 @@ runs:
         echo "Injecting message into existing Devin session..."
         echo "Session ID: $session_id"
         echo "Session URL: $session_url"
+        echo "Org ID: ${DEVIN_ORG_ID:-(not set)}"
 
         # Decode the base64-encoded prompt
         decoded_prompt=$(echo "${{ steps.build-prompt.outputs.prompt }}" | base64 -d || { echo "Error: Failed to decode base64 prompt"; exit 1; })
@@ -458,10 +460,16 @@ runs:
           exit 0
         fi
 
+        # Build curl headers
+        curl_headers=(-H "Authorization: Bearer ${DEVIN_TOKEN}" -H "Content-Type: application/json")
+        if [[ -n "${DEVIN_ORG_ID}" ]]; then
+          echo "Including org-id header for org-scoped authentication"
+          curl_headers+=(-H "X-Devin-Org-Id: ${DEVIN_ORG_ID}")
+        fi
+
         # Make API call to send message to existing session
         response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
-          -H "Authorization: Bearer ${DEVIN_TOKEN}" \
-          -H "Content-Type: application/json" \
+          "${curl_headers[@]}" \
           -d @devin_request.json \
           "https://api.devin.ai/v1/sessions/${session_id}/message")
 


### PR DESCRIPTION
## Summary

When `org-id` is provided alongside `reuse-session`, the action now uses the v3 message endpoint (`POST /v3/organizations/{org_id}/sessions/devin-{session_id}/messages`) instead of the v1 endpoint. This fixes 403 errors when injecting messages into sessions created via the v3 API, which require org-scoped authentication.

Without `org-id`, behavior is unchanged (v1 endpoint).

Changes:
- `inject-message` step selects v3 or v1 endpoint based on `org-id` presence
- Session ID gets `devin-` prefix for v3 endpoint per [API docs](https://docs.devin.ai/api-reference/v3/sessions/post-organizations-sessions-messages)
- Updated input descriptions for `reuse-session` and `org-id` to document the new combination
- Diagnostic logging shows which endpoint and org context is being used

No validation logic changes — `org-id` alone doesn't trigger v3 mode, so the existing `reuse-session` + v3 mutual exclusivity check is unaffected.

## Review & Testing Checklist for Human

- [ ] **Verify `devin-` prefix convention**: The v3 docs say `devin_id` should be `devin-{session_id}`. Confirm session IDs extracted from URLs (e.g. `app.devin.ai/sessions/abc123`) never already carry this prefix — if they do, we'd get `devin-devin-abc123`.
- [ ] **E2E test**: Create a v3 session, then use this action branch with `reuse-session` + `org-id` to inject a message. Verify 200 response. Suggested test: update `airbyte-ops-mcp` triage workflow to reference this branch and re-run the feedback triage flow.
- [ ] **Backward compat**: Run an existing workflow that uses `reuse-session` without `org-id` to confirm v1 path is unchanged.

### Notes
- The `devin-reminders-action` has the same v1-only limitation for its cron firing step (line 479). A similar fix could be applied there if reminders need to target v3-created sessions.
- This unblocks the `forward-thread-to-triage` job in `airbytehq/airbyte-ops-mcp` which was failing with 403 when trying to message a v3-created triage session.

Link to Devin session: https://app.devin.ai/sessions/80f70d2a6b074c2d866f8402e07d04e3
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/devin-action/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
