### PR TITLE
feat: add `structured-output-schema` input (YAML or JSON) for session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A reusable GitHub action which calls out to Devin.ai, creating a new Devin sessi
 | `max-acu-limit` | Maximum ACU limit for the session (v3 API only). | false | |
 | `child-playbook-id` | Playbook ID for child sessions (v3 API only). Required for `batch` and `improve` modes. | false | |
 | `bypass-approval` | If `true`, bypass approval for batch session creation (v3 batch mode only). Requires `UseDevinExpert` permission. | false | `false` |
+| `structured-output-schema` | JSON Schema (as a JSON object) describing the structured output Devin should produce. Supported on both v1 and v3 session creation. Ignored when using `reuse-session`. See [Structured Output](#structured-output) below. | false | |
 
 ## Session Tagging
 
@@ -273,6 +274,69 @@ Use `max-acu-limit` to cap the compute budget for v3 sessions:
     advanced-mode: analyze
     session-links: 'https://app.devin.ai/sessions/abc123'
     max-acu-limit: 5
+```
+
+## Structured Output
+
+Use `structured-output-schema` to request that Devin produce structured output matching a JSON Schema. The schema is passed through as the `structured_output_schema` field on the session creation request. This is supported on both the v1 and v3 session-creation endpoints; it is ignored when using `reuse-session`.
+
+The input must be a JSON-encoded object. It is validated up front: invalid JSON or non-object values fail the action before calling the API.
+
+Once the session is running, the schema tells Devin what shape its "notepad" should take. Clients can then poll the session and read the latest structured output. See the [Devin structured output docs](https://docs.devin.ai/api-reference/structured-output) for more details.
+
+### Inline Schema
+
+```yaml
+- name: Run Devin with Structured Output
+  uses: aaronsteers/devin-action@v1
+  with:
+    devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    prompt-text: |
+      Review this PR and keep the structured output up to date with any issues
+      you find, suggestions you have, and your current approval status.
+    structured-output-schema: |
+      {
+        "type": "object",
+        "properties": {
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "file": { "type": "string" },
+                "line": { "type": "integer" },
+                "type": { "type": "string" },
+                "description": { "type": "string" }
+              }
+            }
+          },
+          "suggestions": { "type": "array", "items": { "type": "string" } },
+          "approved": { "type": "boolean" }
+        },
+        "required": ["approved"]
+      }
+```
+
+### Schema From a File
+
+For longer schemas, store the JSON in a file and pass its contents through a prior step output:
+
+```yaml
+- id: load-schema
+  shell: bash
+  run: |
+    {
+      echo "schema<<EOF"
+      cat .github/schemas/pr-review.json
+      echo "EOF"
+    } >> "$GITHUB_OUTPUT"
+
+- name: Run Devin with Structured Output
+  uses: aaronsteers/devin-action@v1
+  with:
+    devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    prompt-file: .github/prompts/pr-review.md
+    structured-output-schema: ${{ steps.load-schema.outputs.schema }}
 ```
 
 ## Context Gathering

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A reusable GitHub action which calls out to Devin.ai, creating a new Devin sessi
 | `max-acu-limit` | Maximum ACU limit for the session (v3 API only). | false | |
 | `child-playbook-id` | Playbook ID for child sessions (v3 API only). Required for `batch` and `improve` modes. | false | |
 | `bypass-approval` | If `true`, bypass approval for batch session creation (v3 batch mode only). Requires `UseDevinExpert` permission. | false | `false` |
-| `structured-output-schema` | JSON Schema (as a JSON object) describing the structured output Devin should produce. Supported on both v1 and v3 session creation. Ignored when using `reuse-session`. See [Structured Output](#structured-output) below. | false | |
+| `structured-output-schema` | JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Supported on both v1 and v3 session creation. Ignored when using `reuse-session`. See [Structured Output](#structured-output) below. | false | |
 
 ## Session Tagging
 
@@ -280,11 +280,13 @@ Use `max-acu-limit` to cap the compute budget for v3 sessions:
 
 Use `structured-output-schema` to request that Devin produce structured output matching a JSON Schema. The schema is passed through as the `structured_output_schema` field on the session creation request. This is supported on both the v1 and v3 session-creation endpoints; it is ignored when using `reuse-session`.
 
-The input must be a JSON-encoded object. It is validated up front: invalid JSON or non-object values fail the action before calling the API.
+The input accepts either YAML or JSON. YAML 1.2 is a strict superset of JSON, so existing JSON schemas are still valid. The input is validated up front: anything that doesn't parse to a top-level object fails the action before calling the API.
 
 Once the session is running, the schema tells Devin what shape its "notepad" should take. Clients can then poll the session and read the latest structured output. See the [Devin structured output docs](https://docs.devin.ai/api-reference/structured-output) for more details.
 
-### Inline Schema
+### Inline Schema (YAML)
+
+YAML is usually easier to read inside a workflow since you can skip the quotes and braces:
 
 ```yaml
 - name: Run Devin with Structured Output
@@ -295,23 +297,41 @@ Once the session is running, the schema tells Devin what shape its "notepad" sho
       Review this PR and keep the structured output up to date with any issues
       you find, suggestions you have, and your current approval status.
     structured-output-schema: |
+      type: object
+      required: [approved]
+      properties:
+        issues:
+          type: array
+          items:
+            type: object
+            properties:
+              file: { type: string }
+              line: { type: integer }
+              type: { type: string }
+              description: { type: string }
+        suggestions:
+          type: array
+          items: { type: string }
+        approved:
+          type: boolean
+```
+
+### Inline Schema (JSON)
+
+Plain JSON also works unchanged:
+
+```yaml
+- name: Run Devin with Structured Output
+  uses: aaronsteers/devin-action@v1
+  with:
+    devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    prompt-text: "Review this PR and keep the structured output up to date."
+    structured-output-schema: |
       {
         "type": "object",
         "properties": {
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "file": { "type": "string" },
-                "line": { "type": "integer" },
-                "type": { "type": "string" },
-                "description": { "type": "string" }
-              }
-            }
-          },
-          "suggestions": { "type": "array", "items": { "type": "string" } },
-          "approved": { "type": "boolean" }
+          "approved": { "type": "boolean" },
+          "suggestions": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["approved"]
       }
@@ -319,7 +339,7 @@ Once the session is running, the schema tells Devin what shape its "notepad" sho
 
 ### Schema From a File
 
-For longer schemas, store the JSON in a file and pass its contents through a prior step output:
+For longer schemas, store them in a `.yaml` (or `.json`) file and pass the contents through a prior step output:
 
 ```yaml
 - id: load-schema
@@ -327,7 +347,7 @@ For longer schemas, store the JSON in a file and pass its contents through a pri
   run: |
     {
       echo "schema<<EOF"
-      cat .github/schemas/pr-review.json
+      cat .github/schemas/pr-review.yaml
       echo "EOF"
     } >> "$GITHUB_OUTPUT"
 
@@ -338,6 +358,16 @@ For longer schemas, store the JSON in a file and pass its contents through a pri
     prompt-file: .github/prompts/pr-review.md
     structured-output-schema: ${{ steps.load-schema.outputs.schema }}
 ```
+
+### Runner Requirements
+
+Parsing tries the following in order, so any one of these on the runner is enough:
+
+1. `yq` (mikefarah's — preinstalled on GitHub-hosted `ubuntu-latest`).
+2. `python3` with PyYAML (also preinstalled on GitHub-hosted `ubuntu-latest`).
+3. `jq` (JSON-only fallback — `jq` is already a hard dependency of this action).
+
+On minimal self-hosted runners without `yq` or PyYAML, YAML input will be rejected and only JSON will parse.
 
 ## Context Gathering
 

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ inputs:
     required: false
     default: "false"
   structured-output-schema:
-    description: "JSON Schema (as a JSON object) describing the structured output Devin should produce. Supported on both v1 and v3 session creation. Must be a JSON-encoded object (e.g. '{\"type\":\"object\",\"properties\":{...}}'). Ignored when using 'reuse-session'."
+    description: "JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Must parse to a top-level object. Supported on both v1 and v3 session creation. Ignored when using 'reuse-session'."
     required: false
 
 outputs:
@@ -243,12 +243,33 @@ runs:
           exit 1
         fi
 
-        # Validate structured-output-schema is a JSON object (if provided)
+        # Validate structured-output-schema is a YAML or JSON object (if provided).
+        # Accept YAML input (YAML 1.2 is a superset of JSON, so plain JSON also parses).
+        # Normalize to compact JSON and persist via $GITHUB_ENV so downstream steps
+        # don't need to re-parse.
         if [[ -n "$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" | tr -d '[:space:]')" ]]; then
-          if ! printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | jq -e 'type == "object"' >/dev/null 2>&1; then
-            echo "::error::The 'structured-output-schema' input must be a JSON-encoded object (got invalid JSON or non-object value)."
+          schema_json=""
+          if command -v yq >/dev/null 2>&1; then
+            schema_json=$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | yq -o=json eval '.' - 2>/dev/null) || schema_json=""
+          fi
+          if [[ -z "$schema_json" ]] && command -v python3 >/dev/null 2>&1; then
+            schema_json=$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | python3 -c 'import sys, json; import yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' 2>/dev/null) || schema_json=""
+          fi
+          if [[ -z "$schema_json" ]]; then
+            # Last-ditch: try jq for pure JSON (covers runners without yq or PyYAML).
+            schema_json=$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | jq -c '.' 2>/dev/null) || schema_json=""
+          fi
+          if [[ -z "$schema_json" ]]; then
+            echo "::error::Failed to parse 'structured-output-schema' as YAML or JSON. Runner needs 'yq', 'python3' with PyYAML, or valid JSON parseable by 'jq'."
             exit 1
           fi
+          if ! printf '%s' "$schema_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            echo "::error::The 'structured-output-schema' input must be a YAML or JSON object (got a non-object value)."
+            exit 1
+          fi
+          # Persist normalized compact JSON for the Create Session step.
+          schema_json_compact=$(printf '%s' "$schema_json" | jq -c '.')
+          echo "DEVIN_STRUCTURED_OUTPUT_SCHEMA_JSON=${schema_json_compact}" >> "$GITHUB_ENV"
           if [[ -n "${{ inputs.reuse-session }}" ]]; then
             echo "::warning::The 'structured-output-schema' input is only applied when creating a new session; it will be ignored because 'reuse-session' is set."
           fi
@@ -622,15 +643,9 @@ runs:
         # Convert to JSON array
         tags_array=$(printf '%s\n' "${all_tags[@]}" | jq -R . | jq -s .)
 
-        # Parse structured-output-schema once; reused for both v1 and v3 payloads
-        structured_output_schema_json="null"
-        if [[ -n "$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" | tr -d '[:space:]')" ]]; then
-          # Normalize via jq so it serializes cleanly in the payload
-          if ! structured_output_schema_json=$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | jq -c '.'); then
-            echo "::error::Failed to parse 'structured-output-schema' as JSON."
-            exit 1
-          fi
-        fi
+        # Use the normalized JSON persisted by the Validate inputs step.
+        # This is already compact JSON and known to be a top-level object.
+        structured_output_schema_json="${DEVIN_STRUCTURED_OUTPUT_SCHEMA_JSON:-null}"
 
         if [[ "$use_v3" == "true" ]]; then
           # ===== V3 API payload =====

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,9 @@ inputs:
     description: "If 'true', bypass the approval step for session creation (v3 API only). Requires UseDevinExpert permission."
     required: false
     default: "false"
+  structured-output-schema:
+    description: "JSON Schema (as a JSON object) describing the structured output Devin should produce. Supported on both v1 and v3 session creation. Must be a JSON-encoded object (e.g. '{\"type\":\"object\",\"properties\":{...}}'). Ignored when using 'reuse-session'."
+    required: false
 
 outputs:
   session-id:
@@ -108,6 +111,8 @@ runs:
 
     - name: Validate inputs
       shell: bash
+      env:
+        DEVIN_STRUCTURED_OUTPUT_SCHEMA: ${{ inputs.structured-output-schema }}
       run: |
         set -euo pipefail
 
@@ -236,6 +241,17 @@ runs:
         if [[ "$effective_api_version" == "v3" && -n "${{ inputs.reuse-session }}" ]]; then
           echo "::error::The v3 API features and 'reuse-session' are mutually exclusive. The v3 API creates a new session."
           exit 1
+        fi
+
+        # Validate structured-output-schema is a JSON object (if provided)
+        if [[ -n "$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" | tr -d '[:space:]')" ]]; then
+          if ! printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            echo "::error::The 'structured-output-schema' input must be a JSON-encoded object (got invalid JSON or non-object value)."
+            exit 1
+          fi
+          if [[ -n "${{ inputs.reuse-session }}" ]]; then
+            echo "::warning::The 'structured-output-schema' input is only applied when creating a new session; it will be ignored because 'reuse-session' is set."
+          fi
         fi
 
         echo "Input validation passed (effective API version: $effective_api_version)"
@@ -377,6 +393,7 @@ runs:
         echo "child-playbook-id: $([[ -n "${{ inputs.child-playbook-id }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "bypass-approval: ${{ inputs.bypass-approval }}"
         echo "api-version: ${{ inputs.api-version }}"
+        echo "structured-output-schema: $([[ -n "${{ inputs.structured-output-schema }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "::endgroup::"
 
         # Parse reuse-session input if provided
@@ -512,6 +529,7 @@ runs:
       shell: bash
       env:
         DEVIN_TOKEN: ${{ inputs.devin-token }}
+        DEVIN_STRUCTURED_OUTPUT_SCHEMA: ${{ inputs.structured-output-schema }}
       run: |
         set -euo pipefail
 
@@ -602,6 +620,16 @@ runs:
         # Convert to JSON array
         tags_array=$(printf '%s\n' "${all_tags[@]}" | jq -R . | jq -s .)
 
+        # Parse structured-output-schema once; reused for both v1 and v3 payloads
+        structured_output_schema_json="null"
+        if [[ -n "$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" | tr -d '[:space:]')" ]]; then
+          # Normalize via jq so it serializes cleanly in the payload
+          if ! structured_output_schema_json=$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA}" | jq -c '.'); then
+            echo "::error::Failed to parse 'structured-output-schema' as JSON."
+            exit 1
+          fi
+        fi
+
         if [[ "$use_v3" == "true" ]]; then
           # ===== V3 API payload =====
 
@@ -633,6 +661,7 @@ runs:
             --arg playbook "$playbook_id" \
             --arg child_playbook "$child_playbook_id" \
             --arg bypass "$bypass_approval" \
+            --argjson structured_output_schema "$structured_output_schema_json" \
             '{
               "prompt": $prompt,
               "tags": $tags
@@ -642,7 +671,8 @@ runs:
             | if $max_acu != "" then . + {"max_acu_limit": ($max_acu | tonumber)} else . end
             | if $playbook != "" then . + {"playbook_id": $playbook} else . end
             | if $child_playbook != "" then . + {"child_playbook_id": $child_playbook} else . end
-            | if $bypass == "true" then . + {"bypass_approval": true} else . end' > devin_request.json
+            | if $bypass == "true" then . + {"bypass_approval": true} else . end
+            | if $structured_output_schema != null then . + {"structured_output_schema": $structured_output_schema} else . end' > devin_request.json
 
         else
           # ===== V1 API payload =====
@@ -668,13 +698,15 @@ runs:
             --arg branch "${{ github.ref_name }}" \
             --argjson tags "$tags_array" \
             --argjson metadata "$metadata_json" \
+            --argjson structured_output_schema "$structured_output_schema_json" \
             '{
               "prompt": $prompt,
               "repository_url": $repo_url,
               "branch": $branch,
               "tags": $tags,
               "metadata": $metadata
-            }' > devin_request.json
+            }
+            | if $structured_output_schema != null then . + {"structured_output_schema": $structured_output_schema} else . end' > devin_request.json
         fi
 
         echo "::group::📤 Devin API Request"

--- a/action.yml
+++ b/action.yml
@@ -371,6 +371,8 @@ runs:
     - name: Resolve session vars
       id: resolve-vars
       shell: bash
+      env:
+        DEVIN_STRUCTURED_OUTPUT_SCHEMA: ${{ inputs.structured-output-schema }}
       run: |
         set -euo pipefail
 
@@ -393,7 +395,7 @@ runs:
         echo "child-playbook-id: $([[ -n "${{ inputs.child-playbook-id }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "bypass-approval: ${{ inputs.bypass-approval }}"
         echo "api-version: ${{ inputs.api-version }}"
-        echo "structured-output-schema: $([[ -n "${{ inputs.structured-output-schema }}" ]] && echo 'SET' || echo 'NOT SET')"
+        echo "structured-output-schema: $([[ -n "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "::endgroup::"
 
         # Parse reuse-session input if provided


### PR DESCRIPTION
## Summary

Adds a new `structured-output-schema` input that forwards a user-supplied JSON Schema to the Devin API as the `structured_output_schema` field on session creation. This lets callers ask Devin to keep structured notes matching a schema they control, which can then be read back by polling the session.

Requested by @aaronsteers in Slack: "Please add structured_output_schema to devin-action repo."

**Behavior**

- Input accepts *YAML or JSON*. YAML 1.2 is a strict superset of JSON, so existing JSON schemas are still valid; YAML is typically easier to read inside a workflow.
- Validated up-front in the `Validate inputs` step — anything that doesn't parse to a top-level object fails the action before any API call.
- Wired into both the v1 and v3 `create session` payloads (it's supported by both endpoints per the [Devin API docs](https://docs.devin.ai/api-reference/structured-output)).
- Ignored with a warning when `reuse-session` is set, since session creation is what accepts this field.
- Schema is passed through env var (`DEVIN_STRUCTURED_OUTPUT_SCHEMA`) rather than inline `${{ }}` substitution, to avoid shell-escaping issues with arbitrary JSON/YAML.
- Normalized compact JSON is persisted between steps via `$GITHUB_ENV` (`DEVIN_STRUCTURED_OUTPUT_SCHEMA_JSON`), so the create-session step doesn't re-parse.

**Parser fallback chain**

Parsing tries, in order, so any one of these on the runner is enough:

1. `yq` (mikefarah's — preinstalled on GitHub-hosted `ubuntu-latest`).
2. `python3` with PyYAML (also preinstalled on GitHub-hosted `ubuntu-latest`).
3. `jq` (JSON-only fallback — `jq` is already a hard dependency of this action).

**README**

New "Structured Output" section with a YAML inline example, a JSON inline example, a file-loading example, and a runner-requirements note, plus a row in the inputs table.

## Review & Testing Checklist for Human

- [ ] Verify the `structured_output_schema` field is actually accepted and honored by both v1 (`POST /v1/sessions`) and v3 (`POST /v3/organizations/{org_id}/sessions`) — easiest way is to run the action with a small schema and then `GET` the session and check the `structured_output` field.
- [ ] Confirm the validation step behaves correctly on malformed input (unparseable YAML/JSON, YAML array, YAML scalar) — those should fail fast with a clear error before hitting the API.
- [ ] Confirm the debug output doesn't leak anything unexpected — the "Input Summary" group only prints `SET`/`NOT SET` for the schema, but the `📤 Devin API Request` group echoes the full payload including the schema (this matches how other inputs are surfaced today).
- [ ] Sanity-check behavior on a minimal self-hosted runner that has only `jq` (no `yq`, no PyYAML): JSON input should still work, YAML input should fail with a clear error message.

### Notes

- Did not wire `structured_output_schema` into the `reuse-session` message-inject path — the v1 `POST /v1/sessions/{id}/message` and v3 `POST /v3/organizations/{org_id}/sessions/{devin_id}/messages` endpoints don't accept this field; it only applies at session creation. Using both inputs together now emits a `::warning::` at validation time so it's visible in the logs.
- Parser logic was validated locally against YAML-with-comments, flow-style YAML, plain JSON, a JSON-array (rejected as non-object), and a broken input (rejected as unparseable).
- Playbook frontmatter / schema-embedded-in-playbook ergonomics are intentionally out of scope here — Devin playbooks don't have a native frontmatter concept (`body`/`title`/`macro` only), and the action currently only receives the playbook macro name, not the playbook body. Can be layered on later as a frontmatter parser over `prompt-file`/`prompt-text`.

Link to Devin session: https://app.devin.ai/sessions/6b5971ddeebf4a27bbca60eacbc0af40