### PR TITLE
feat: add `title` input for v3 API session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A reusable GitHub action which calls out to Devin.ai, creating a new Devin sessi
 | `max-acu-limit` | Maximum ACU limit for the session (v3 API only). | false | |
 | `child-playbook-id` | Playbook ID for child sessions (v3 API only). Required for `batch` and `improve` modes. | false | |
 | `bypass-approval` | If `true`, bypass approval for batch session creation (v3 batch mode only). Requires `UseDevinExpert` permission. | false | `false` |
+| `title` | Custom title for the session (v3 API only). Sets the session's display title instead of inheriting from the prompt. Useful for automated workflows where the prompt is long but you want a short, descriptive title. | false | |
 | `structured-output-schema` | JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Supported on both v1 and v3 session creation. Ignored when using `reuse-session`. See [Structured Output](#structured-output) below. | false | |
 
 ## Session Tagging

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ inputs:
     required: false
     default: "false"
   title:
-    description: "Custom title for the session (optional, v3 API only). If provided, sets the session's display title instead of inheriting from the prompt. Useful for automated workflows where the prompt is long but you want a short, descriptive title."
+    description: "Custom title for the session (optional, v3 API only). If provided, sets the session's display title instead of inheriting from the prompt. Useful for helping human users and administrators quickly locate and identify sessions by purpose and/or by origin."
     required: false
   structured-output-schema:
     description: "JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Must parse to a top-level object. Supported on both v1 and v3 session creation. Ignored when using 'reuse-session'."

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,9 @@ inputs:
     description: "If 'true', bypass the approval step for session creation (v3 API only). Requires UseDevinExpert permission."
     required: false
     default: "false"
+  title:
+    description: "Custom title for the session (optional, v3 API only). If provided, sets the session's display title instead of inheriting from the prompt. Useful for automated workflows where the prompt is long but you want a short, descriptive title."
+    required: false
   structured-output-schema:
     description: "JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Must parse to a top-level object. Supported on both v1 and v3 session creation. Ignored when using 'reuse-session'."
     required: false
@@ -181,6 +184,9 @@ runs:
         fi
         if [[ "$bypass_approval" == "true" ]]; then
           v3_only_features+=("bypass-approval")
+        fi
+        if [[ -n "${{ inputs.title }}" ]]; then
+          v3_only_features+=("title")
         fi
 
         # Error if v1 is explicitly requested with v3-only features
@@ -415,6 +421,7 @@ runs:
         echo "playbook-id: $([[ -n "${{ inputs.playbook-id }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "child-playbook-id: $([[ -n "${{ inputs.child-playbook-id }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "bypass-approval: ${{ inputs.bypass-approval }}"
+        echo "title: $([[ -n "${{ inputs.title }}" ]] && echo 'SET (${{ inputs.title }})' || echo 'NOT SET')"
         echo "api-version: ${{ inputs.api-version }}"
         echo "structured-output-schema: $([[ -n "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "::endgroup::"
@@ -669,6 +676,7 @@ runs:
           fi
 
           # Build v3 request payload
+          session_title="${{ inputs.title }}"
           jq -n \
             --arg prompt "$decoded_prompt" \
             --arg advanced_mode "$advanced_mode" \
@@ -678,6 +686,7 @@ runs:
             --arg playbook "$playbook_id" \
             --arg child_playbook "$child_playbook_id" \
             --arg bypass "$bypass_approval" \
+            --arg title "$session_title" \
             --argjson structured_output_schema "$structured_output_schema_json" \
             '{
               "prompt": $prompt,
@@ -689,6 +698,7 @@ runs:
             | if $playbook != "" then . + {"playbook_id": $playbook} else . end
             | if $child_playbook != "" then . + {"child_playbook_id": $child_playbook} else . end
             | if $bypass == "true" then . + {"bypass_approval": true} else . end
+            | if $title != "" then . + {"title": $title} else . end
             | if $structured_output_schema != null then . + {"structured_output_schema": $structured_output_schema} else . end' > devin_request.json
 
         else

--- a/action.yml
+++ b/action.yml
@@ -572,6 +572,7 @@ runs:
         playbook_id="${{ inputs.playbook-id }}"
         child_playbook_id="${{ inputs.child-playbook-id }}"
         bypass_approval="${{ inputs.bypass-approval }}"
+        session_title="${{ inputs.title }}"
 
         # session-links without advanced-mode defaults to analyze
         if [[ -z "$advanced_mode" && -n "$session_links_input" ]]; then
@@ -580,7 +581,7 @@ runs:
 
         # Determine effective API version
         if [[ "$api_version" == "auto" ]]; then
-          if [[ -n "$advanced_mode" || -n "$session_links_input" || -n "$max_acu_limit" || -n "$playbook_id" || -n "$child_playbook_id" || "$bypass_approval" == "true" ]]; then
+          if [[ -n "$advanced_mode" || -n "$session_links_input" || -n "$max_acu_limit" || -n "$playbook_id" || -n "$child_playbook_id" || "$bypass_approval" == "true" || -n "$session_title" ]]; then
             use_v3="true"
           else
             use_v3="false"
@@ -676,7 +677,6 @@ runs:
           fi
 
           # Build v3 request payload
-          session_title="${{ inputs.title }}"
           jq -n \
             --arg prompt "$decoded_prompt" \
             --arg advanced_mode "$advanced_mode" \

--- a/action.yml
+++ b/action.yml
@@ -421,7 +421,7 @@ runs:
         echo "playbook-id: $([[ -n "${{ inputs.playbook-id }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "child-playbook-id: $([[ -n "${{ inputs.child-playbook-id }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "bypass-approval: ${{ inputs.bypass-approval }}"
-        echo "title: $([[ -n "${{ inputs.title }}" ]] && echo 'SET (${{ inputs.title }})' || echo 'NOT SET')"
+        echo "title: $([[ -n "${{ inputs.title }}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "api-version: ${{ inputs.api-version }}"
         echo "structured-output-schema: $([[ -n "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" ]] && echo 'SET' || echo 'NOT SET')"
         echo "::endgroup::"


### PR DESCRIPTION
## Summary

Adds a new `title` input parameter that allows callers to set a custom display title on sessions created via the v3 API. Previously, there was no way to control the session title from the action — sessions would inherit a title derived from the prompt text, which is often unhelpful for automated workflows with long prompts.

The `title` is:
- Passed through to the v3 API payload only when non-empty
- Treated as a v3-only feature for input validation (errors if used with `api-version: v1`)
- Included in the debug input summary output
- Documented in the README inputs table

## Review & Testing Checklist for Human

Low risk — additive change, no existing behavior modified.

- [ ] Verify the `title` field appears in the v3 JSON payload when set (check the `📤 Devin API Request` log group in a test run)
- [ ] Verify no `title` field in the payload when the input is omitted
- [ ] Confirm the created session shows the custom title in the Devin UI

### Notes

Requested by @aaronsteers. This unblocks setting descriptive titles on auto-triage sessions created by the `devin-session-triage.yml` workflow in `airbytehq/airbyte-ops-mcp`.

Link to Devin session: https://app.devin.ai/sessions/e924e8eedb114b3cae2a80e082a92ad3