### PR TITLE
feat!: require Devin API v3

### DIFF
--- a/.github/workflows/ai-ask-command.yml
+++ b/.github/workflows/ai-ask-command.yml
@@ -33,5 +33,6 @@ jobs:
           issue-number: ${{ github.event.inputs.issue-number }}
           playbook-macro: "!issue_ask"
           devin-token: ${{ secrets.DEVIN_TOKEN }}
+          org-id: ${{ vars.DEVIN_ORG_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           start-message: "💡 **Getting AI assistance...**"

--- a/.github/workflows/ai-fix-command.yml
+++ b/.github/workflows/ai-fix-command.yml
@@ -33,5 +33,6 @@ jobs:
           issue-number: ${{ github.event.inputs.issue-number }}
           playbook-macro: "!issue_fix"
           devin-token: ${{ secrets.DEVIN_TOKEN }}
+          org-id: ${{ vars.DEVIN_ORG_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           start-message: "🔧 **Running AI fix analysis...**"

--- a/.github/workflows/devin-command.yml
+++ b/.github/workflows/devin-command.yml
@@ -43,4 +43,5 @@ jobs:
           playbook-macro: ${{ github.event.inputs.playbook-macro }}
           prompt-text: ${{ github.event.inputs.prompt-text }}
           devin-token: ${{ secrets.DEVIN_TOKEN }}
+          org-id: ${{ vars.DEVIN_ORG_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,10 +19,23 @@ jobs:
         with:
           prompt-text: "This is a test of the Devin action"
           devin-token: "test-token-placeholder"
+          org-id: "org-test-placeholder"
+          dry-run: "true"
+
+      - name: Test Action fails fast with unsupported API version
+        id: test-unsupported-version
+        uses: ./
+        with:
+          prompt-text: "This should fail before calling the Devin API"
+          devin-token: "test-token-placeholder"
+          org-id: "org-test-placeholder"
+          api-version: "v1"
+          dry-run: "true"
         continue-on-error: true
 
       - name: Check test results
         run: |
-          echo "Test completed with exit code: ${{ steps.test-minimal.outcome }}"
-          # In a real test, we would validate the outputs
-          # For now, we just ensure the action doesn't crash on basic input validation
+          echo "Minimal dry-run outcome: ${{ steps.test-minimal.outcome }}"
+          echo "Unsupported version outcome: ${{ steps.test-unsupported-version.outcome }}"
+          test "${{ steps.test-minimal.outcome }}" = "success"
+          test "${{ steps.test-unsupported-version.outcome }}" = "failure"

--- a/README.md
+++ b/README.md
@@ -27,18 +27,19 @@ A reusable GitHub action which calls out to Devin.ai, creating a new Devin sessi
 | `github-token` | GitHub Token (required for posting comments and accessing repo context)    | false    |          |
 | `start-message`| Custom message for the start comment                                       | false    | 🤖 **Starting Devin AI session...** |
 | `tags`         | Additional tags to apply to the Devin session (supports CSV or line-delimited format). Automatic tags are always added: `gh-actions-trigger` and `playbook-{macro-name}` if playbook-macro is provided. Cannot be used with `reuse-session`. | false    |          |
-| `reuse-session`| Existing Devin session ID or URL to inject a message into. Accepts either a session ID or a full URL (e.g., `https://app.devin.ai/sessions/abc123`). When provided, sends a message to an existing session instead of creating a new one. Mutually exclusive with `tags`. | false    |          |
-| `wait-for-stopped-status` | If `true`, polls until `status_enum` is any non-`working` state. | false | `false` |
+| `reuse-session`| Existing Devin v3 session ID or URL to inject a message into. Accepts either a session ID or a full URL (e.g., `https://app.devin.ai/sessions/abc123`). When provided, sends a message to an existing session instead of creating a new one. Requires `org-id` and is mutually exclusive with `tags`. | false    |          |
+| `wait-for-stopped-status` | If `true`, polls until `status_detail` is any non-`working` state. | false | `false` |
 | `wait-minutes-max` | Maximum minutes to poll before timing out (only used when `wait-for-stopped-status` is enabled) | false | `20` |
-| `api-version` | Devin API version: `auto` (default), `v1`, or `v3`. When `auto`, resolves to v3 if v3-only features are used; otherwise v1. Setting `v1` with v3-only features errors. | false | `auto` |
-| `advanced-mode` | V3 API advanced mode. Options: `analyze`, `create`, `improve`, `batch`, `manage`. Requires `org-id`. See [Advanced Mode](#advanced-mode-v3-api) below. | false | |
+| `api-version` | Devin API version. Only `v3` is supported; any other value fails fast. | false | `v3` |
+| `advanced-mode` | V3 API advanced mode. Option: `analyze`. Requires `org-id`. See [Advanced Mode](#advanced-mode-v3-api) below. | false | |
 | `session-links` | Session URLs or IDs to analyze (CSV or line-delimited). Required for `analyze` mode. When provided without `advanced-mode`, defaults to `analyze`. | false | |
-| `org-id` | Devin organization ID. Required when using v3 API features (`advanced-mode` or `session-links`). | false | |
-| `max-acu-limit` | Maximum ACU limit for the session (v3 API only). | false | |
-| `child-playbook-id` | Playbook ID for child sessions (v3 API only). Required for `batch` and `improve` modes. | false | |
-| `bypass-approval` | If `true`, bypass approval for batch session creation (v3 batch mode only). Requires `UseDevinExpert` permission. | false | `false` |
-| `structured-output-schema` | JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). When provided, `api-version: auto` resolves to v3 and `structured_output_required` defaults to `true`. Ignored when using `reuse-session`. See [Structured Output](#structured-output) below. | false | |
-| `structured-output-required` | V3-only flag passed as `structured_output_required` on session creation. Defaults to `true` when `structured-output-schema` is provided. Set to `false` to make structured output available but optional. Ignored when using `reuse-session`. | false | |
+| `org-id` | Devin organization ID. Required for v3 session creation, session reuse, and polling. | false | |
+| `max-acu-limit` | Maximum ACU limit for the session. | false | |
+| `playbook-id` | Playbook ID to use for the session. | false | |
+| `child-playbook-id` | Playbook ID for child sessions. | false | |
+| `bypass-approval` | If `true`, bypass approval for session creation. Requires `UseDevinExpert` permission. | false | `false` |
+| `structured-output-schema` | JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Defaults `structured_output_required` to `true`. Ignored when using `reuse-session`. See [Structured Output](#structured-output) below. | false | |
+| `structured-output-required` | Flag passed as `structured_output_required` on session creation. Defaults to `true` when `structured-output-schema` is provided. Set to `false` to make structured output available but optional. Ignored when using `reuse-session`. | false | |
 
 ## Session Tagging
 
@@ -87,6 +88,7 @@ tags: |
   with:
     prompt-text: "Please review this code and suggest improvements"
     devin-token: ${{ secrets.DEVIN_TOKEN }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
     tags: 'code-review,improvement'
 ```
@@ -102,6 +104,7 @@ This action is designed to work with slash commands in issue and PR comments. Th
     comment-id: ${{ github.event.comment.id }}
     issue-number: ${{ github.event.issue.number }}
     devin-token: ${{ secrets.DEVIN_TOKEN }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -115,6 +118,7 @@ This action is designed to work with slash commands in issue and PR comments. Th
     issue-number: ${{ github.event.issue.number }}
     prompt-text: "Additional context about the specific failure"
     devin-token: ${{ secrets.DEVIN_TOKEN }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
     tags: |
       ci-failure
@@ -139,6 +143,7 @@ You can provide either a session ID or a full session URL:
       New task triggered at ${{ github.event.repository.updated_at }}
       Please process the following scope: all certified connectors
     devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
 
 # Using a session URL (session ID is automatically extracted)
 - name: Send Message to Existing Devin Session
@@ -149,6 +154,7 @@ You can provide either a session ID or a full session URL:
       New task triggered at ${{ github.event.repository.updated_at }}
       Please process the following scope: all certified connectors
     devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
 ```
 
 **Note:** The `reuse-session` input is mutually exclusive with `tags`. When injecting a message into an existing session, tags cannot be specified since they are only applicable when creating new sessions.
@@ -164,6 +170,7 @@ Use `wait-for-stopped-status` to poll the Devin session until it reaches any non
   id: devin
   with:
     devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
     prompt-text: "Analyze commits and write a summary..."
     wait-for-stopped-status: true
 ```
@@ -175,6 +182,7 @@ Use `wait-for-stopped-status` to poll the Devin session until it reaches any non
   id: create
   with:
     devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
     prompt-text: "Do something..."
 
 # ... other steps ...
@@ -183,6 +191,7 @@ Use `wait-for-stopped-status` to poll the Devin session until it reaches any non
   id: wait
   with:
     devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+    org-id: ${{ vars.DEVIN_ORG_ID }}
     reuse-session: ${{ steps.create.outputs.session-id }}
     wait-for-stopped-status: true
 ```
@@ -191,10 +200,10 @@ When polling completes, the following additional outputs are available:
 
 | Output | Description |
 |--------|-------------|
-| `status` | The terminal `status_enum` value when polling completes |
+| `status` | The terminal `status_detail` value when polling completes |
 | `summary` | The last message from the session |
 
-The action waits for any `status_enum` value other than `working`. See the [Devin API docs](https://docs.devin.ai/api-reference/v1/sessions/retrieve-details-about-an-existing-session) for the full list of possible status values.
+The action waits for any `status_detail` value other than `working`. See the [Devin API docs](https://docs.devin.ai/api-reference/v3/sessions/get-organizations-session) for the full list of possible status values.
 
 ## Advanced Mode (v3 API)
 
@@ -202,23 +211,7 @@ The action supports the Devin v3 API's advanced mode, which enables specialized 
 
 ### API Version Selection
 
-The `api-version` input controls which Devin API endpoint is used:
-
-- **`auto`** (default): Automatically selects v3 when v3-only features (`advanced-mode`, `session-links`, `max-acu-limit`) are provided; otherwise uses v1.
-- **`v1`**: Forces the v1 API. Will error if any v3-only features are also provided.
-- **`v3`**: Forces the v3 API. Requires `org-id`.
-
-When `advanced-mode` or `session-links` is provided, the action automatically uses the v3 API endpoint (equivalent to `api-version: auto` behavior).
-
-### Available Modes
-
-| Mode | Description | Required Parameters |
-|------|-------------|---------------------|
-| `analyze` | Analyze existing Devin sessions to extract insights | `session-links` |
-| `create` | Create a new playbook based on session analysis | None (optional: `session-links`) |
-| `improve` | Improve an existing playbook based on feedback | None |
-| `batch` | Start multiple Devin sessions for a list of tasks | None |
-| `manage` | Manage knowledge | None |
+The action only supports the Devin v3 API. The `api-version` input defaults to `v3`; setting it to anything else fails before any Devin API call is made. All create, message, and polling calls require `org-id`.
 
 ### Prerequisites
 
@@ -237,7 +230,7 @@ This is particularly useful for automated triage workflows where one Devin sessi
   uses: aaronsteers/devin-action@v1
   with:
     prompt-text: "Triage the linked session and identify the root cause of the reported issue."
-    devin-token: ${{ secrets.DEVIN_V3_TOKEN }}
+    devin-token: ${{ secrets.DEVIN_TOKEN }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
     org-id: ${{ secrets.DEVIN_ORG_ID }}
     advanced-mode: analyze
@@ -256,7 +249,7 @@ When `session-links` is provided without `advanced-mode`, the action automatical
   uses: aaronsteers/devin-action@v1
   with:
     prompt-text: "Review this session and summarize what happened."
-    devin-token: ${{ secrets.DEVIN_V3_TOKEN }}
+    devin-token: ${{ secrets.DEVIN_TOKEN }}
     org-id: ${{ secrets.DEVIN_ORG_ID }}
     session-links: 'https://app.devin.ai/sessions/abc123'
 ```
@@ -270,7 +263,7 @@ Use `max-acu-limit` to cap the compute budget for v3 sessions:
   uses: aaronsteers/devin-action@v1
   with:
     prompt-text: "Quick analysis of this session."
-    devin-token: ${{ secrets.DEVIN_V3_TOKEN }}
+    devin-token: ${{ secrets.DEVIN_TOKEN }}
     org-id: ${{ secrets.DEVIN_ORG_ID }}
     advanced-mode: analyze
     session-links: 'https://app.devin.ai/sessions/abc123'
@@ -281,7 +274,7 @@ Use `max-acu-limit` to cap the compute budget for v3 sessions:
 
 Use `structured-output-schema` to request that Devin produce structured output matching a JSON Schema. The schema is passed through as the `structured_output_schema` field on the v3 session creation request; it is ignored when using `reuse-session`.
 
-When `structured-output-schema` is provided, `api-version: auto` resolves to v3 and the action defaults `structured_output_required` to `true`. This means Devin must call `provide_structured_output` with `is_final=true` before its turn ends. Set `structured-output-required: "false"` to make the tool available but optional; in that mode, it is not guaranteed to be called in a given turn.
+When `structured-output-schema` is provided, the action defaults `structured_output_required` to `true`. This means Devin must call `provide_structured_output` with `is_final=true` before its turn ends. Set `structured-output-required: "false"` to make the tool available but optional; in that mode, it is not guaranteed to be called in a given turn.
 
 The input accepts either YAML or JSON. YAML 1.2 is a strict superset of JSON, so existing JSON schemas are still valid. The input is validated up front: anything that doesn't parse to a top-level object fails the action before calling the API.
 
@@ -435,6 +428,7 @@ jobs:
           issue-number: ${{ github.event.client_payload.slash_command.args.named.issue || inputs.issue-number }}
           playbook-macro: '!issue_help'
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          org-id: ${{ vars.DEVIN_ORG_ID }}
           github-token: ${{ secrets.MY_COMMENTS_PAT }}
           start-message: '🤖 **AI Help session starting...**'
 ```

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,7 @@ inputs:
   devin-token:
     description: |
       Devin API Token (required for authentication).
-      For v1 API: Personal API Key (apk_user_*) or Service API Key (apk_*).
-      For v3 API: Service User credential with ManageOrgSessions permission (service users only; PATs are not supported for v3).
+      Requires a v3-compatible service user credential with ManageOrgSessions permission (service users only; PATs are not supported for v3).
     required: true
   github-token:
     description: "GitHub Token (required for posting comments and accessing repo context)"
@@ -38,14 +37,14 @@ inputs:
     description: "Additional tags to apply to the Devin session (supports CSV or line-delimited format). Automatic tags are always added: gh-actions-trigger and playbook-{macro-name} if playbook-macro is provided. Cannot be used with reuse-session."
     required: false
   reuse-session:
-    description: "Existing Devin session ID or URL to inject a message into (optional). When provided, sends a message to an existing session instead of creating a new one. Accepts either a session ID or a full URL (e.g., https://app.devin.ai/sessions/abc123). Mutually exclusive with 'tags' input. When targeting a session created via the v3 API, also provide 'org-id' for org-scoped authentication."
+    description: "Existing Devin session ID or URL to inject a message into (optional). When provided, sends a message to an existing v3 session instead of creating a new one. Accepts either a session ID or a full URL (e.g., https://app.devin.ai/sessions/abc123). Mutually exclusive with 'tags' input. Requires 'org-id'."
     required: false
   dry-run:
     description: "If 'true', the action will simulate the process without making an actual API call to Devin"
     required: false
     default: "false"
   wait-for-stopped-status:
-    description: "If 'true', polls GET /v1/sessions/{session_id} until status_enum is any non-working state."
+    description: "If 'true', polls GET /v3/organizations/{org_id}/sessions/{devin_id} until status_detail is any non-working state."
     required: false
     default: "false"
   wait-minutes-max:
@@ -53,17 +52,17 @@ inputs:
     required: false
     default: "20"
   api-version:
-    description: "Devin API version to use. Options: 'auto' (default, selects v1 or v3 based on inputs), 'v1' (force v1 API), 'v3' (force v3 API). When 'auto', v3 is used if advanced-mode or session-links is provided; otherwise v1. Setting 'v1' with v3-only features (advanced-mode, session-links, max-acu-limit) will produce an error."
+    description: "Devin API version to use. Only 'v3' is supported; any other value fails fast."
     required: false
-    default: "auto"
+    default: "v3"
   advanced-mode:
-    description: "V3 API advanced mode (optional). Enables specialized session behaviors for automation workflows. Options: 'analyze' (analyze existing sessions via session-links), 'create' (create a new playbook), 'improve' (improve an existing playbook), 'batch' (start multiple sessions), 'manage' (manage knowledge). When set, uses the v3 API endpoint. Requires org-id."
+    description: "V3 API advanced mode (optional). Enables specialized session behaviors for automation workflows. Options: 'analyze' (analyze existing sessions via session-links). Requires org-id."
     required: false
   session-links:
     description: "Session URLs or IDs to provide as context (optional, supports CSV or line-delimited format). Required when advanced-mode is 'analyze'. When provided without advanced-mode, defaults to 'analyze' mode automatically."
     required: false
   org-id:
-    description: "Devin organization ID (required when using v3 API features such as advanced-mode or session-links). Also used with reuse-session to authenticate against sessions created via the v3 API. For org-scoped service users this may be auto-resolved, but providing it explicitly is recommended."
+    description: "Devin organization ID. Required for v3 session creation, session reuse, and polling."
     required: false
   max-acu-limit:
     description: "Maximum ACU limit for the session (optional, v3 API only). Caps the compute budget for the session."
@@ -72,17 +71,17 @@ inputs:
     description: "Playbook ID to use for the session (v3 API only). When set, the session will follow the referenced playbook's instructions. The playbook must already exist in the Devin API (synced via the ai-skills repo or created manually)."
     required: false
   child-playbook-id:
-    description: "Playbook ID for child sessions (v3 API only). Required when advanced-mode is 'batch' or 'improve'."
+    description: "Playbook ID for child sessions (v3 API only)."
     required: false
   bypass-approval:
     description: "If 'true', bypass the approval step for session creation (v3 API only). Requires UseDevinExpert permission."
     required: false
     default: "false"
   structured-output-schema:
-    description: "JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Must parse to a top-level object. Supported on both v1 and v3 session creation. Ignored when using 'reuse-session'."
+    description: "JSON Schema describing the structured output Devin should produce. Accepts YAML or JSON (YAML 1.2 is a superset of JSON, so plain JSON also works). Must parse to a top-level object. Ignored when using 'reuse-session'."
     required: false
   structured-output-required:
-    description: "If 'true', require Devin to submit final structured output before each turn ends when using the v3 API. If 'false', structured output remains available but optional. Ignored for v1 session creation and when using 'reuse-session'."
+    description: "If 'true', require Devin to submit final structured output before each turn ends. If 'false', structured output remains available but optional. Ignored when using 'reuse-session'."
     required: false
 
 outputs:
@@ -102,7 +101,7 @@ outputs:
     description: "The GitHub Actions run URL"
     value: ${{ steps.vars.outputs.run-url }}
   status:
-    description: "The terminal status_enum value when polling completes (only set when wait-for-stopped-status is enabled)"
+    description: "The terminal status_detail value when polling completes (only set when wait-for-stopped-status is enabled)"
     value: ${{ steps.wait-for-status.outputs.status }}
   summary:
     description: "The last message from the session (only set when wait-for-stopped-status is enabled)"
@@ -141,23 +140,15 @@ runs:
 
         # Validate api-version input
         api_version="${{ inputs.api-version }}"
-        case "$api_version" in
-          auto|v1|v3)
-            ;;
-          *)
-            echo "::error::Invalid api-version '$api_version'. Must be one of: auto, v1, v3."
-            exit 1
-            ;;
-        esac
+        if [[ "$api_version" != "v3" ]]; then
+          echo "::error::Invalid api-version '$api_version'. Devin API v1 support has been removed; api-version must be 'v3'."
+          exit 1
+        fi
 
         # Validate v3 API inputs
         advanced_mode="${{ inputs.advanced-mode }}"
         session_links="${{ inputs.session-links }}"
         org_id="${{ inputs.org-id }}"
-        max_acu_limit="${{ inputs.max-acu-limit }}"
-        playbook_id="${{ inputs.playbook-id }}"
-        child_playbook_id="${{ inputs.child-playbook-id }}"
-        bypass_approval="${{ inputs.bypass-approval }}"
         structured_output_required="${{ inputs.structured-output-required }}"
 
         # Determine effective advanced mode (session-links implies analyze)
@@ -166,63 +157,20 @@ runs:
           echo "::notice::session-links provided without advanced-mode; defaulting to 'analyze' mode."
         fi
 
-        # Collect v3-only features for validation
-        v3_only_features=()
-        if [[ -n "$advanced_mode" ]]; then
-          v3_only_features+=("advanced-mode")
-        fi
-        if [[ -n "$session_links" ]]; then
-          v3_only_features+=("session-links")
-        fi
-        if [[ -n "$max_acu_limit" ]]; then
-          v3_only_features+=("max-acu-limit")
-        fi
-        if [[ -n "$playbook_id" ]]; then
-          v3_only_features+=("playbook-id")
-        fi
-        if [[ -n "$child_playbook_id" ]]; then
-          v3_only_features+=("child-playbook-id")
-        fi
-        if [[ "$bypass_approval" == "true" ]]; then
-          v3_only_features+=("bypass-approval")
-        fi
-        if [[ -n "$structured_output_required" ]]; then
-          v3_only_features+=("structured-output-required")
-        fi
-
-        # Error if v1 is explicitly requested with v3-only features
-        if [[ "$api_version" == "v1" && ${#v3_only_features[@]} -gt 0 ]]; then
-          features_list=$(IFS=', '; echo "${v3_only_features[*]}")
-          echo "::error::api-version is 'v1' but the following v3-only features were provided: ${features_list}. Either remove these inputs or set api-version to 'v3' or 'auto'."
-          exit 1
-        fi
-
-        # Resolve effective API version
-        if [[ "$api_version" == "auto" ]]; then
-          if [[ ${#v3_only_features[@]} -gt 0 ]]; then
-            effective_api_version="v3"
-            echo "::notice::api-version is 'auto'; resolved to 'v3' because v3 features are in use (${v3_only_features[*]})."
-          else
-            effective_api_version="v1"
-          fi
-        else
-          effective_api_version="$api_version"
-        fi
-
-        # If effective version is v3, org-id is required
-        if [[ "$effective_api_version" == "v3" && -z "$org_id" ]]; then
-          echo "::error::The 'org-id' input is required when using the v3 API (either explicitly or auto-resolved from v3-only features)."
+        # org-id is required for all v3 API calls
+        if [[ -z "$org_id" ]]; then
+          echo "::error::The 'org-id' input is required when using the v3 API."
           exit 1
         fi
 
         # Validate advanced-mode value
         if [[ -n "$advanced_mode" ]]; then
           case "$advanced_mode" in
-            analyze|create|improve|batch|manage)
+            analyze)
               echo "Advanced mode: $advanced_mode"
               ;;
             *)
-              echo "::error::Invalid advanced-mode '$advanced_mode'. Must be one of: analyze, create, improve, batch, manage."
+              echo "::error::Invalid advanced-mode '$advanced_mode'. Must be: analyze."
               exit 1
               ;;
           esac
@@ -233,16 +181,6 @@ runs:
           echo "::error::The 'session-links' input is required when advanced-mode is 'analyze'."
           exit 1
         fi
-
-        # batch and improve modes require child-playbook-id
-        if [[ "$advanced_mode" == "batch" || "$advanced_mode" == "improve" ]]; then
-          if [[ -z "$child_playbook_id" ]]; then
-            echo "::error::The 'child-playbook-id' input is required when advanced-mode is '$advanced_mode'."
-            exit 1
-          fi
-        fi
-
-        # bypass-approval is a v3 feature (no longer restricted to batch mode only)
 
         if [[ -n "$structured_output_required" ]]; then
           case "$structured_output_required" in
@@ -259,12 +197,6 @@ runs:
           if [[ -n "${{ inputs.reuse-session }}" ]]; then
             echo "::warning::The 'structured-output-required' input is only applied when creating a new v3 session; it will be ignored because 'reuse-session' is set."
           fi
-        fi
-
-        # v3 features are incompatible with reuse-session
-        if [[ "$effective_api_version" == "v3" && -n "${{ inputs.reuse-session }}" ]]; then
-          echo "::error::The v3 API features and 'reuse-session' are mutually exclusive. The v3 API creates a new session."
-          exit 1
         fi
 
         # Validate structured-output-schema is a YAML or JSON object (if provided).
@@ -299,7 +231,7 @@ runs:
           fi
         fi
 
-        echo "Input validation passed (effective API version: $effective_api_version)"
+        echo "Input validation passed (API version: v3)"
 
     - name: Build Devin prompt
       id: build-prompt
@@ -472,11 +404,7 @@ runs:
           session_url="https://app.devin.ai/sessions/${session_id}"
           echo "Final session ID: $session_id"
           echo "Final session URL: $session_url"
-          if [[ -n "${{ inputs.org-id }}" ]]; then
-            echo "API endpoint: POST /v3/organizations/{org_id}/sessions/devin-${session_id}/messages (org-scoped)"
-          else
-            echo "API endpoint: POST /v1/sessions/${session_id}/message"
-          fi
+          echo "API endpoint: POST /v3/organizations/{org_id}/sessions/devin-${session_id}/messages"
           echo "::endgroup::"
           
           # Output resolved values
@@ -529,17 +457,9 @@ runs:
           exit 0
         fi
 
-        # Select API endpoint based on whether org-id is provided
-        if [[ -n "${DEVIN_ORG_ID}" ]]; then
-          # Use v3 message endpoint for org-scoped sessions (e.g. sessions created via v3 API)
-          devin_id="devin-${session_id}"
-          api_url="https://api.devin.ai/v3/organizations/${DEVIN_ORG_ID}/sessions/${devin_id}/messages"
-          echo "Using v3 message endpoint (org-scoped): POST /v3/organizations/{org_id}/sessions/${devin_id}/messages"
-        else
-          # Use v1 message endpoint for personal sessions
-          api_url="https://api.devin.ai/v1/sessions/${session_id}/message"
-          echo "Using v1 message endpoint: POST /v1/sessions/${session_id}/message"
-        fi
+        devin_id="devin-${session_id}"
+        api_url="https://api.devin.ai/v3/organizations/${DEVIN_ORG_ID}/sessions/${devin_id}/messages"
+        echo "Using v3 message endpoint: POST /v3/organizations/{org_id}/sessions/${devin_id}/messages"
 
         # Make API call to send message to existing session
         response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
@@ -581,8 +501,6 @@ runs:
       run: |
         set -euo pipefail
 
-        # Resolve API version (mirrors validation logic)
-        api_version="${{ inputs.api-version }}"
         advanced_mode="${{ inputs.advanced-mode }}"
         session_links_input="${{ inputs.session-links }}"
         org_id="${{ inputs.org-id }}"
@@ -597,36 +515,12 @@ runs:
           advanced_mode="analyze"
         fi
 
-        # Determine effective API version
-        has_structured_output_schema=false
-        if [[ -n "$(printf '%s' "${DEVIN_STRUCTURED_OUTPUT_SCHEMA:-}" | tr -d '[:space:]')" ]]; then
-          has_structured_output_schema=true
-        fi
+        api_endpoint="https://api.devin.ai/v3/organizations/${org_id}/sessions"
 
-        if [[ "$api_version" == "auto" ]]; then
-          if [[ -n "$advanced_mode" || -n "$session_links_input" || -n "$max_acu_limit" || -n "$playbook_id" || -n "$child_playbook_id" || "$bypass_approval" == "true" || -n "$structured_output_required" || "$has_structured_output_schema" == "true" ]]; then
-            use_v3="true"
-          else
-            use_v3="false"
-          fi
-        elif [[ "$api_version" == "v3" ]]; then
-          use_v3="true"
-        else
-          use_v3="false"
-        fi
-
-        if [[ "$use_v3" == "true" ]]; then
-          api_endpoint="https://api.devin.ai/v3/organizations/${org_id}/sessions"
-
-          echo "::group::🆕 New Session Configuration (v3 API)"
-          echo "API endpoint: POST /v3/organizations/{org_id}/sessions"
-          echo "Advanced mode: $advanced_mode"
-          echo "Organization ID: $org_id"
-        else
-          api_endpoint="https://api.devin.ai/v1/sessions"
-          echo "::group::🆕 New Session Configuration (v1 API)"
-          echo "API endpoint: POST /v1/sessions"
-        fi
+        echo "::group::🆕 New Session Configuration (v3 API)"
+        echo "API endpoint: POST /v3/organizations/{org_id}/sessions"
+        echo "Advanced mode: $advanced_mode"
+        echo "Organization ID: $org_id"
         echo "Repository: ${{ github.repository }}"
         echo "Branch: ${{ github.ref_name }}"
         echo "::endgroup::"
@@ -681,86 +575,48 @@ runs:
           structured_output_required="true"
         fi
 
-        if [[ "$use_v3" == "true" ]]; then
-          # ===== V3 API payload =====
-
-          # Parse session-links (supports CSV and line-delimited)
-          session_links_json="null"
-          if [[ -n "$session_links_input" ]]; then
-            session_links_arr=()
-            while IFS= read -r line; do
-              if [[ -n "$line" ]]; then
-                IFS=',' read -ra link_array <<< "$line"
-                for link in "${link_array[@]}"; do
-                  trimmed_link=$(echo "$link" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                  if [[ -n "$trimmed_link" ]]; then
-                    session_links_arr+=("$trimmed_link")
-                  fi
-                done
-              fi
-            done <<< "$session_links_input"
-            session_links_json=$(printf '%s\n' "${session_links_arr[@]}" | jq -R . | jq -s .)
-          fi
-
-          # Build v3 request payload
-          jq -n \
-            --arg prompt "$decoded_prompt" \
-            --arg advanced_mode "$advanced_mode" \
-            --argjson tags "$tags_array" \
-            --argjson session_links "$session_links_json" \
-            --arg max_acu "$max_acu_limit" \
-            --arg playbook "$playbook_id" \
-            --arg child_playbook "$child_playbook_id" \
-            --arg bypass "$bypass_approval" \
-            --arg structured_output_required "$structured_output_required" \
-            --argjson structured_output_schema "$structured_output_schema_json" \
-            '{
-              "prompt": $prompt,
-              "tags": $tags
-            }
-            | if $advanced_mode != "" then . + {"advanced_mode": $advanced_mode} else . end
-            | if $session_links != null then . + {"session_links": $session_links} else . end
-            | if $max_acu != "" then . + {"max_acu_limit": ($max_acu | tonumber)} else . end
-            | if $playbook != "" then . + {"playbook_id": $playbook} else . end
-            | if $child_playbook != "" then . + {"child_playbook_id": $child_playbook} else . end
-            | if $bypass == "true" then . + {"bypass_approval": true} else . end
-            | if $structured_output_required != "" then . + {"structured_output_required": ($structured_output_required == "true")} else . end
-            | if $structured_output_schema != null then . + {"structured_output_schema": $structured_output_schema} else . end' > devin_request.json
-
-        else
-          # ===== V1 API payload =====
-
-          # Build metadata object with optional fields
-          metadata_json=$(jq -n \
-            --arg run_id "${{ github.run_id }}" \
-            --arg repository "${{ github.repository }}" \
-            --arg comment_id "${{ inputs.comment-id }}" \
-            --arg issue_number "${{ inputs.issue-number }}" \
-            '{
-              "github_run_id": $run_id,
-              "github_repository": $repository,
-              "triggered_by": "github_action"
-            }
-            | if $comment_id != "" then . + {"github_comment_id": $comment_id, "github_comment_url": "https://github.com/\($repository)/issues/comments/\($comment_id)"} else . end
-            | if $issue_number != "" then . + {"github_issue_number": $issue_number, "github_issue_url": "https://github.com/\($repository)/issues/\($issue_number)"} else . end')
-
-          # Prepare the v1 API request payload
-          jq -n \
-            --arg prompt "$decoded_prompt" \
-            --arg repo_url "https://github.com/${{ github.repository }}" \
-            --arg branch "${{ github.ref_name }}" \
-            --argjson tags "$tags_array" \
-            --argjson metadata "$metadata_json" \
-            --argjson structured_output_schema "$structured_output_schema_json" \
-            '{
-              "prompt": $prompt,
-              "repository_url": $repo_url,
-              "branch": $branch,
-              "tags": $tags,
-              "metadata": $metadata
-            }
-            | if $structured_output_schema != null then . + {"structured_output_schema": $structured_output_schema} else . end' > devin_request.json
+        # Parse session-links (supports CSV and line-delimited)
+        session_links_json="null"
+        if [[ -n "$session_links_input" ]]; then
+          session_links_arr=()
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              IFS=',' read -ra link_array <<< "$line"
+              for link in "${link_array[@]}"; do
+                trimmed_link=$(echo "$link" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                if [[ -n "$trimmed_link" ]]; then
+                  session_links_arr+=("$trimmed_link")
+                fi
+              done
+            fi
+          done <<< "$session_links_input"
+          session_links_json=$(printf '%s\n' "${session_links_arr[@]}" | jq -R . | jq -s .)
         fi
+
+        # Build v3 request payload
+        jq -n \
+          --arg prompt "$decoded_prompt" \
+          --arg advanced_mode "$advanced_mode" \
+          --argjson tags "$tags_array" \
+          --argjson session_links "$session_links_json" \
+          --arg max_acu "$max_acu_limit" \
+          --arg playbook "$playbook_id" \
+          --arg child_playbook "$child_playbook_id" \
+          --arg bypass "$bypass_approval" \
+          --arg structured_output_required "$structured_output_required" \
+          --argjson structured_output_schema "$structured_output_schema_json" \
+          '{
+            "prompt": $prompt,
+            "tags": $tags
+          }
+          | if $advanced_mode != "" then . + {"advanced_mode": $advanced_mode} else . end
+          | if $session_links != null then . + {"session_links": $session_links} else . end
+          | if $max_acu != "" then . + {"max_acu_limit": ($max_acu | tonumber)} else . end
+          | if $playbook != "" then . + {"playbook_id": $playbook} else . end
+          | if $child_playbook != "" then . + {"child_playbook_id": $child_playbook} else . end
+          | if $bypass == "true" then . + {"bypass_approval": true} else . end
+          | if $structured_output_required != "" then . + {"structured_output_required": ($structured_output_required == "true")} else . end
+          | if $structured_output_schema != null then . + {"structured_output_schema": $structured_output_schema} else . end' > devin_request.json
 
         echo "::group::📤 Devin API Request"
         cat devin_request.json | jq
@@ -787,9 +643,9 @@ runs:
         echo "$response" | jq
         echo "::endgroup::"
 
-        # Extract session information (v1 uses session_url, v3 uses url)
-        session_id=$(echo "$response" | jq -r '.session_id // .id // empty')
-        session_url=$(echo "$response" | jq -r '.session_url // .url // empty')
+        # Extract session information
+        session_id=$(echo "$response" | jq -r '.session_id // empty')
+        session_url=$(echo "$response" | jq -r '.url // empty')
 
         if [[ -z "$session_id" ]]; then
           echo "Failed to extract session ID from Devin API response"
@@ -821,6 +677,9 @@ runs:
           exit 1
         fi
 
+        org_id="${{ inputs.org-id }}"
+        devin_id="devin-${session_id}"
+
         # Internal defaults
         poll_interval=30
         max_api_errors=3
@@ -836,7 +695,8 @@ runs:
 
         echo "::group::⏳ Polling Configuration"
         echo "Session ID: $session_id"
-        echo "Waiting for any non-working status"
+        echo "API endpoint: GET /v3/organizations/{org_id}/sessions/${devin_id}"
+        echo "Waiting for any non-working status_detail"
         echo "Poll interval: ${poll_interval}s"
         echo "Max polls: $max_polls"
         echo "Max consecutive API errors: $max_api_errors"
@@ -854,7 +714,7 @@ runs:
           response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X GET \
             -H "Authorization: Bearer ${DEVIN_TOKEN}" \
             -H "Content-Type: application/json" \
-            "https://api.devin.ai/v1/sessions/${session_id}" 2>&1) || true
+            "https://api.devin.ai/v3/organizations/${org_id}/sessions/${devin_id}" 2>&1) || true
 
           http_status=$(echo "$response" | grep "HTTP_STATUS:" | cut -d':' -f2)
           response_body=$(echo "$response" | sed '/HTTP_STATUS:/d')
@@ -875,8 +735,8 @@ runs:
           # Reset consecutive error counter on success
           consecutive_errors=0
 
-          # Extract status_enum from response, treating JSON parse failures as retryable errors
-          if ! current_status=$(echo "$response_body" | jq -r '.status_enum // empty' 2>/dev/null); then
+          # Extract status_detail from response, treating JSON parse failures as retryable errors
+          if ! current_status=$(echo "$response_body" | jq -r '.status_detail // empty' 2>/dev/null); then
             consecutive_errors=$((consecutive_errors + 1))
             echo "::warning::Failed to parse JSON response (attempt $consecutive_errors/$max_api_errors)."
             if [[ $consecutive_errors -ge $max_api_errors ]]; then
@@ -886,9 +746,9 @@ runs:
             sleep "$poll_interval"
             continue
           fi
-          echo "  Current status_enum: $current_status"
+          echo "  Current status_detail: $current_status"
 
-          # Any non-working status means the session has stopped
+          # Any non-working status_detail means the session has stopped
           if [[ "$current_status" != "working" && -n "$current_status" ]]; then
             echo "Session reached non-working status: $current_status"
 

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
     required: false
   org-id:
     description: "Devin organization ID. Required for v3 session creation, session reuse, and polling."
-    required: false
+    required: true
   max-acu-limit:
     description: "Maximum ACU limit for the session (optional, v3 API only). Caps the compute budget for the session."
     required: false
@@ -628,7 +628,7 @@ runs:
         fi
 
         # Make API call to Devin
-        response=$(curl -s -X POST \
+        response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
           -H "Authorization: Bearer ${DEVIN_TOKEN}" \
           -H "Content-Type: application/json" \
           -d @devin_request.json \
@@ -639,16 +639,27 @@ runs:
           exit 1
         fi
 
+        http_status=$(echo "$response" | grep "HTTP_STATUS:" | cut -d':' -f2)
+        response_body=$(echo "$response" | sed '/HTTP_STATUS:/d')
+
         echo "::group::📥 Devin API Response"
-        echo "$response" | jq
+        echo "HTTP Status: $http_status"
+        echo "$response_body" | jq . 2>/dev/null || echo "$response_body"
         echo "::endgroup::"
 
+        if [[ -z "$http_status" || "$http_status" -lt 200 || "$http_status" -ge 300 ]]; then
+          echo "::error::Failed to create Devin session. HTTP Status: ${http_status:-unknown}"
+          echo "Response: $response_body"
+          exit 1
+        fi
+
         # Extract session information
-        session_id=$(echo "$response" | jq -r '.session_id // empty')
-        session_url=$(echo "$response" | jq -r '.url // empty')
+        session_id=$(echo "$response_body" | jq -r '.session_id // empty')
+        session_url=$(echo "$response_body" | jq -r '.url // empty')
 
         if [[ -z "$session_id" ]]; then
           echo "Failed to extract session ID from Devin API response"
+          echo "Response: $response_body"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary
Requested by AJ Steers.

- Remove v1/auto API selection and require `api-version: v3`, failing fast for any other value.
- Route session creation, message injection, and status polling through the v3 organization-scoped endpoints.
- Update docs, built-in workflows, and action tests for required `org-id` and v3 `status_detail` polling.

## Review & Testing Checklist for Human
- [ ] Confirm existing workflows have `vars.DEVIN_ORG_ID` configured before adopting this breaking change.
- [ ] Verify a real v3 service user token can create a new session and inject into an existing session with `org-id`.
- [ ] Verify `wait-for-stopped-status` polling reaches terminal `status_detail` values as expected.

### Notes
Local checks run:
- `git diff --check`
- `yq eval '.'` on `action.yml` and workflow YAML files
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`

This intentionally does not include the semver bump to 1.0.

Link to Devin session: https://app.devin.ai/sessions/c1c780d8a28c4ece9e787572e1a69c2d
Requested by: @aaronsteers