### PR TITLE
ci: add live production action test plan

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -5,6 +5,23 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  workflow_dispatch:
+    inputs:
+      run-live-tests:
+        description: "Create a real Devin v3 session using DEVIN_TOKEN and DEVIN_ORG_ID"
+        type: boolean
+        required: true
+        default: false
+      live-prompt-text:
+        description: "Prompt for the live Devin session"
+        type: string
+        required: false
+        default: "Live production smoke test for aaronsteers/devin-action. Confirm the session was created successfully. Do not modify repositories, create pull requests, or post external comments."
+      wait-for-stopped-status:
+        description: "Poll the live session until status_detail is non-working"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   test-action:
@@ -39,3 +56,51 @@ jobs:
           echo "Unsupported version outcome: ${{ steps.test-unsupported-version.outcome }}"
           test "${{ steps.test-minimal.outcome }}" = "success"
           test "${{ steps.test-unsupported-version.outcome }}" = "failure"
+
+  live-prod-smoke-test:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-live-tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate live test configuration
+        env:
+          DEVIN_TOKEN: ${{ secrets.DEVIN_TOKEN }}
+          DEVIN_ORG_ID: ${{ vars.DEVIN_ORG_ID }}
+        run: |
+          test -n "$DEVIN_TOKEN"
+          test -n "$DEVIN_ORG_ID"
+
+      - name: Create live Devin session
+        id: create-live-session
+        uses: ./
+        with:
+          prompt-text: ${{ inputs.live-prompt-text }}
+          devin-token: ${{ secrets.DEVIN_TOKEN }}
+          org-id: ${{ vars.DEVIN_ORG_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            devin-action-live-prod-test
+            workflow-${{ github.run_id }}
+            ref-${{ github.ref_name }}
+          max-acu-limit: "1"
+          wait-for-stopped-status: ${{ inputs.wait-for-stopped-status }}
+          wait-minutes-max: "10"
+
+      - name: Check live session outputs
+        run: |
+          session_id='${{ steps.create-live-session.outputs.session-id }}'
+          session_url='${{ steps.create-live-session.outputs.session-url }}'
+          status='${{ steps.create-live-session.outputs.status }}'
+
+          test -n "$session_id"
+          test -n "$session_url"
+
+          {
+            echo "### Live production smoke test"
+            echo ""
+            echo "- Session ID: $session_id"
+            echo "- Session URL: $session_url"
+            echo "- Status: ${status:-not polled}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A reusable GitHub action which calls out to Devin.ai, creating a new Devin sessi
 | `api-version` | Devin API version. Only `v3` is supported; any other value fails fast. | false | `v3` |
 | `advanced-mode` | V3 API advanced mode. Option: `analyze`. Requires `org-id`. See [Advanced Mode](#advanced-mode-v3-api) below. | false | |
 | `session-links` | Session URLs or IDs to analyze (CSV or line-delimited). Required for `analyze` mode. When provided without `advanced-mode`, defaults to `analyze`. | false | |
-| `org-id` | Devin organization ID. Required for v3 session creation, session reuse, and polling. | false | |
+| `org-id` | Devin organization ID. Required for v3 session creation, session reuse, and polling. | true | |
 | `max-acu-limit` | Maximum ACU limit for the session. | false | |
 | `playbook-id` | Playbook ID to use for the session. | false | |
 | `child-playbook-id` | Playbook ID for child sessions. | false | |

--- a/docs/live-prod-test-plan.md
+++ b/docs/live-prod-test-plan.md
@@ -1,0 +1,54 @@
+# Live production test plan
+
+Use this plan to validate a release candidate against the real Devin v3 API before merging or publishing it.
+
+## Prerequisites
+
+- Repository secret `DEVIN_TOKEN` is set to a v3-compatible Devin service user credential with `ManageOrgSessions`.
+- Repository variable `DEVIN_ORG_ID` is set to the target Devin organization ID.
+- The `Test Action` workflow has `workflow_dispatch` available on the default branch.
+- The candidate branch contains the action changes to validate.
+
+## Pre-merge workflow-dispatch test
+
+1. Open GitHub Actions for the repository.
+2. Select the `Test Action` workflow.
+3. Choose `Run workflow`.
+4. Select the candidate PR branch in the branch selector.
+5. Set `run-live-tests` to `true`.
+6. Keep the default prompt unless validating a specific prompt shape.
+7. Keep `wait-for-stopped-status` as `false` for a fast session-creation smoke test. Set it to `true` only when validating polling behavior.
+8. Start the workflow.
+
+Expected result:
+
+- The dry-run job passes.
+- The unsupported-version fail-fast check passes by failing the `api-version: v1` step before any Devin API call.
+- The live smoke-test job creates one real Devin v3 session using production secrets.
+- The live job summary includes a non-empty session ID and session URL.
+- The created session has the `devin-action-live-prod-test`, `workflow-<run_id>`, and `ref-<branch>` tags.
+
+## Optional focused live checks
+
+Run these only when the corresponding behavior changed:
+
+1. `wait-for-stopped-status`: dispatch `Test Action` with `run-live-tests=true` and `wait-for-stopped-status=true`. Passes when polling finishes with a non-empty `status` output before `wait-minutes-max`.
+2. Comment posting: dispatch one of the slash-command workflows against a throwaway issue or PR comment and confirm the start comment is updated with a Devin session link.
+3. Session reuse: run the action from a temporary workflow or local branch with `reuse-session` set to the session ID from the live smoke test, and confirm the message lands in that same session.
+4. Advanced analyze mode: run the action with `advanced-mode: analyze` and `session-links` pointing at a test session, then confirm the v3 request succeeds.
+
+## Safety boundaries
+
+- Use prompts that explicitly tell Devin not to modify repositories, create pull requests, or post external comments.
+- Do not include customer data, private issue context, or secrets in test prompts.
+- Use `max-acu-limit: "1"` for the live smoke test.
+- Prefer testing on throwaway GitHub issues or draft PRs when comment posting is part of the validation.
+
+## Release-candidate pass criteria
+
+A release candidate is ready to merge when:
+
+- Local YAML/action lint validation passes.
+- Pull request CI passes.
+- The workflow-dispatch live smoke test passes on the candidate branch.
+- Any optional focused live checks relevant to the change pass.


### PR DESCRIPTION
## Summary
Adds a workflow-dispatch path to the existing `Test Action` workflow so release-candidate branches can be tested against live Devin v3 production assets before merge.

Changes:
- Adds manual `workflow_dispatch` inputs to `.github/workflows/test-action.yml`.
- Adds an opt-in `live-prod-smoke-test` job gated by `run-live-tests=true`.
- Creates one real Devin v3 session using `DEVIN_TOKEN` and `DEVIN_ORG_ID`, with `max-acu-limit: "1"`, test tags, and safe default prompt text.
- Documents the pre-merge live-prod-assets test plan in `docs/live-prod-test-plan.md`.
- Fixes the README input table so `org-id` is documented as required, matching `action.yml`.

## Review & Testing Checklist for Human
- [ ] Confirm the repository has `DEVIN_TOKEN` and `DEVIN_ORG_ID` configured for live workflow-dispatch tests.
- [ ] Dispatch `Test Action` on this PR branch with `run-live-tests=true` and confirm the live smoke-test job creates a session and reports non-empty outputs.
- [ ] Review `docs/live-prod-test-plan.md` and confirm the pass criteria match the intended 1.0.0 release-candidate process.

### Notes
Local validation passed:
- `git diff --check`
- `yq eval '.' action.yml`
- `yq eval '.' .github/workflows/test-action.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/test-action.yml`

Link to Devin session: https://app.devin.ai/sessions/c1c780d8a28c4ece9e787572e1a69c2d
Requested by: @aaronsteers